### PR TITLE
Ensure envelope encryption of EKS secrets is enabled

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -69,5 +69,19 @@ resource "aws_eks_cluster" "tfgoat" {
     aws_iam_role_policy_attachment.tfgoat-cluster-AmazonEKSVPCResourceController,
     aws_iam_role_policy_attachment.tfgoat-cluster-AmazonEKSVPCResourceController,
   ]
+  encryption_config {           
+    provider {
+      key_arn = aws_kms_key.example.arn
+    }            
+    resources = [ "secrets" ]
+  }
 }
+
+# [Shisho]: See the following document:
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "example" {
+  description             = "example"
+  deletion_window_in_days = 10
+}
+
 


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Evelope encryption of EKS secrets works as an additional layer of encryption.

