### PR TITLE
Ensure coarse ingress configuration of a security group is intended

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -32,14 +32,14 @@ resource "aws_security_group" "tfgoat-cluster" {
   name        = "${local.prefix}-tfgoat-cluster"
   description = "Cluster communication with worker nodes"
   vpc_id      = aws_vpc.tfgoat.id
-
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    # [Shisho]: You can ignore this report by adding the following comment:
+    # shisho: mark-as-intended aws-vpc-ensure-coarse-sg-ingress-is-intended
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
     cidr_blocks = ["0.0.0.0/0"]
   }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -47,6 +47,7 @@ resource "aws_security_group" "tfgoat-cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
 
 resource "aws_security_group_rule" "tfgoat-cluster-ingress-workstation-https" {
   cidr_blocks       = ["0.0.0.0/0"]


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Your security group defines all ingress ports are open, exposing resources in the VPC to unwanted attacks. Check this configuration is intended.

