### PR TITLE
Ensure to enable control plane logging of your EKS cluster

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -76,7 +76,10 @@ resource "aws_eks_cluster" "tfgoat" {
     }            
     resources = [ "secrets" ]
   }
+  # [Shisho]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#enabled_cluster_log_types
+  enabled_cluster_log_types = ["api", "authenticator", "audit", "scheduler", "controllerManager"]
 }
+
 
 # [Shisho]: See the following document:
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to enable EKS control plane logging, which provides diagnostic logs of your clusters to detect anomalous activities.

